### PR TITLE
#5 Register user [ Close #5 ]

### DIFF
--- a/src/main/java/org/quizzcloud/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/org/quizzcloud/backend/auth/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -41,13 +42,12 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/login").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
-                        .requestMatchers("/api/users").permitAll()
-                        .requestMatchers("/users/**").hasAuthority("ADMIN")
+                        .requestMatchers("/api/users").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthEntryPoint))

--- a/src/main/java/org/quizzcloud/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/org/quizzcloud/backend/auth/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/login").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/api/users").permitAll()
                         .requestMatchers("/users/**").hasAuthority("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/quizzcloud/backend/auth/controller/UserController.java
+++ b/src/main/java/org/quizzcloud/backend/auth/controller/UserController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.quizzcloud.backend.auth.dto.UserRegisterRequest;
 import org.quizzcloud.backend.auth.model.User;
 import org.quizzcloud.backend.auth.service.RegisterUserService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +19,7 @@ public class UserController {
 
     @PostMapping
     public ResponseEntity<User> registerNewUser(@RequestBody UserRegisterRequest request) {
-        String email = request.email();
-        return ResponseEntity.ok(registerUserService.registerUser(email, request.role()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(registerUserService.registerUser(request.email(), request.role()));
     }
 }

--- a/src/main/java/org/quizzcloud/backend/auth/controller/UserController.java
+++ b/src/main/java/org/quizzcloud/backend/auth/controller/UserController.java
@@ -3,23 +3,30 @@ package org.quizzcloud.backend.auth.controller;
 import lombok.RequiredArgsConstructor;
 import org.quizzcloud.backend.auth.dto.UserRegisterRequest;
 import org.quizzcloud.backend.auth.model.User;
+import org.quizzcloud.backend.auth.service.FindUsersService;
 import org.quizzcloud.backend.auth.service.RegisterUserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
     private final RegisterUserService registerUserService;
+    private final FindUsersService findUsersService;
 
     @PostMapping
     public ResponseEntity<User> registerNewUser(@RequestBody UserRegisterRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(registerUserService.registerUser(request.email(), request.role()));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<User>> findUsersList() {
+        List<User> users = findUsersService.findAllUsers();
+        return ResponseEntity.ok(users);
     }
 }

--- a/src/main/java/org/quizzcloud/backend/auth/controller/UserController.java
+++ b/src/main/java/org/quizzcloud/backend/auth/controller/UserController.java
@@ -1,0 +1,24 @@
+package org.quizzcloud.backend.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.quizzcloud.backend.auth.dto.UserRegisterRequest;
+import org.quizzcloud.backend.auth.model.User;
+import org.quizzcloud.backend.auth.service.RegisterUserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final RegisterUserService registerUserService;
+
+    @PostMapping
+    public ResponseEntity<User> registerNewUser(@RequestBody UserRegisterRequest request) {
+        String email = request.email();
+        return ResponseEntity.ok(registerUserService.registerUser(email, request.role()));
+    }
+}

--- a/src/main/java/org/quizzcloud/backend/auth/dto/UserRegisterRequest.java
+++ b/src/main/java/org/quizzcloud/backend/auth/dto/UserRegisterRequest.java
@@ -1,0 +1,7 @@
+package org.quizzcloud.backend.auth.dto;
+
+public record UserRegisterRequest(
+        String role,
+        String email
+) {
+}

--- a/src/main/java/org/quizzcloud/backend/auth/repository/UserRepository.java
+++ b/src/main/java/org/quizzcloud/backend/auth/repository/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }
 

--- a/src/main/java/org/quizzcloud/backend/auth/service/FindUsersService.java
+++ b/src/main/java/org/quizzcloud/backend/auth/service/FindUsersService.java
@@ -1,0 +1,18 @@
+package org.quizzcloud.backend.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.quizzcloud.backend.auth.model.User;
+import org.quizzcloud.backend.auth.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FindUsersService {
+    private final UserRepository userRepository;
+
+    public List<User> findAllUsers() {
+        return userRepository.findAll();
+    }
+}

--- a/src/main/java/org/quizzcloud/backend/auth/service/PasswordGenerator.java
+++ b/src/main/java/org/quizzcloud/backend/auth/service/PasswordGenerator.java
@@ -1,0 +1,23 @@
+package org.quizzcloud.backend.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+public class PasswordGenerator {
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_+=<>?";
+    private static final int PASSWORD_LENGTH = 12;
+
+    public static String generateRandomPassword() {
+        SecureRandom random = new SecureRandom();
+        StringBuilder password = new StringBuilder(PASSWORD_LENGTH);
+
+        for (int i = 0; i < PASSWORD_LENGTH; i++) {
+            int index = random.nextInt(CHARACTERS.length());
+            password.append(CHARACTERS.charAt(index));
+        }
+
+        return password.toString();
+    }
+}

--- a/src/main/java/org/quizzcloud/backend/auth/service/RegisterUserService.java
+++ b/src/main/java/org/quizzcloud/backend/auth/service/RegisterUserService.java
@@ -1,0 +1,52 @@
+package org.quizzcloud.backend.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quizzcloud.backend.auth.model.Role;
+import org.quizzcloud.backend.auth.model.User;
+import org.quizzcloud.backend.auth.repository.UserRepository;
+import org.quizzcloud.backend.shared.exceptions.ResourceAlreadyExistsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RegisterUserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User registerUser(String email, String role) {
+        if (userRepository.existsByEmail(email)) {
+            throw new ResourceAlreadyExistsException("User already exists with email:" + email);
+        }
+
+        if (role == null || role.isEmpty()) {
+            log.error("Role cannot be null or empty");
+            throw new IllegalArgumentException("Role cannot be null or empty");
+
+        }
+        Role userRole = Role.valueOf(role.toUpperCase());
+
+        String createDefaultPassword = createRandomDefaultPassword();
+        String encodeDefaultPassword = encodeDefaultPassword(createDefaultPassword);
+
+        User newUser = new User();
+        newUser.setEmail(email);
+        newUser.setRole(userRole);
+        newUser.setPassword(encodeDefaultPassword);
+
+        userRepository.save(newUser);
+        log.info("User created: " + email + " / " + createDefaultPassword);
+
+        return newUser;
+    }
+
+    private String createRandomDefaultPassword() {
+        return PasswordGenerator.generateRandomPassword();
+    }
+
+    private String encodeDefaultPassword(String createDefaultPassword) {
+        return passwordEncoder.encode(createDefaultPassword);
+    }
+}

--- a/src/main/java/org/quizzcloud/backend/auth/service/RegisterUserService.java
+++ b/src/main/java/org/quizzcloud/backend/auth/service/RegisterUserService.java
@@ -28,25 +28,25 @@ public class RegisterUserService {
         }
         Role userRole = Role.valueOf(role.toUpperCase());
 
-        String createDefaultPassword = createRandomDefaultPassword();
-        String encodeDefaultPassword = encodeDefaultPassword(createDefaultPassword);
+        String plainPassword = generateRandomPassword();
+        String encodedPassword = encodePassword(plainPassword);
 
         User newUser = new User();
         newUser.setEmail(email);
         newUser.setRole(userRole);
-        newUser.setPassword(encodeDefaultPassword);
+        newUser.setPassword(encodedPassword);
 
         userRepository.save(newUser);
-        log.info("User created: " + email + " / " + createDefaultPassword);
+        log.info("User created: {} / {}", email, plainPassword);
 
         return newUser;
     }
 
-    private String createRandomDefaultPassword() {
+    private String generateRandomPassword() {
         return PasswordGenerator.generateRandomPassword();
     }
 
-    private String encodeDefaultPassword(String createDefaultPassword) {
+    private String encodePassword(String createDefaultPassword) {
         return passwordEncoder.encode(createDefaultPassword);
     }
 }

--- a/src/main/java/org/quizzcloud/backend/shared/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/quizzcloud/backend/shared/exceptions/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package org.quizzcloud.backend.shared.exceptions;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -35,6 +33,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleResourceNotFound(ResourceNotFoundException ex) {
         LOGGER.warn("Resource not found: {}", ex.getMessage());
         return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(ResourceAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleResourceAlreadyExists(ResourceAlreadyExistsException ex) {
+        LOGGER.warn("Resource already exists: {}", ex.getMessage());
+        return buildResponse(HttpStatus.CONFLICT, ex.getMessage());
     }
 
     /**

--- a/src/main/java/org/quizzcloud/backend/shared/exceptions/ResourceAlreadyExistsException.java
+++ b/src/main/java/org/quizzcloud/backend/shared/exceptions/ResourceAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package org.quizzcloud.backend.shared.exceptions;
+
+public class ResourceAlreadyExistsException extends RuntimeException {
+    public ResourceAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/org/quizzcloud/backend/acceptance/auth/FindUsersTest.java
+++ b/src/test/java/org/quizzcloud/backend/acceptance/auth/FindUsersTest.java
@@ -1,0 +1,18 @@
+package org.quizzcloud.backend.acceptance.auth;
+
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+class FindUsersTest extends AcceptanceBaseTest {
+
+    @Test
+    void finsAllUsers() throws Exception {
+        String adminToken = getAdminToken();
+
+        mockMvc.perform(get("/api/users")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/org/quizzcloud/backend/acceptance/auth/RegisterUserTest.java
+++ b/src/test/java/org/quizzcloud/backend/acceptance/auth/RegisterUserTest.java
@@ -1,0 +1,69 @@
+package org.quizzcloud.backend.acceptance.auth;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.quizzcloud.backend.auth.model.Role;
+import org.quizzcloud.backend.auth.model.User;
+import org.quizzcloud.backend.auth.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RegisterUserTest extends AcceptanceBaseTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void whenAdminRegisterNewUser_thenUserIsCreated() throws Exception {
+        String adminToken = getAdminToken();
+        String userEmail = "newUser@gmail.com";
+
+        String registerRequestJson = """
+                {
+                    "email": "%s",
+                    "role": "%s"
+                }
+                """.formatted(userEmail, "ADMIN");
+
+        mockMvc.perform(post("/api/users")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType("application/json")
+                        .content(registerRequestJson))
+                .andExpect(status().isCreated());
+
+        // Verify that the user was created in the database
+        User newUser = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new AssertionError("User should have been created: " + userEmail));
+
+        assertAll(
+                () -> assertEquals(userEmail, newUser.getEmail(), "Email does not match"),
+                () -> assertEquals(Role.ADMIN, newUser.getRole(), "Role should be ADMIN")
+        );
+    }
+
+    @Test
+    void whenUserRegisterNewUser_thenReturnsNonAuthorizes() throws Exception {
+        String userToken = getUserToken();
+        String userEmail = "newUser@gmail.com";
+
+        String registerRequestJson = """
+                {
+                    "email": "%s",
+                    "role": "%s"
+                }
+                """.formatted(userEmail, "ADMIN");
+
+        mockMvc.perform(post("/api/users")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType("application/json")
+                        .content(registerRequestJson))
+                .andExpect(status().isForbidden());
+
+        // Verify that the user was not created in the database
+        boolean userExists = userRepository.existsByEmail(userEmail);
+        Assertions.assertFalse(userExists, "User should not have been created");
+    }
+}


### PR DESCRIPTION

- [x] Register a new User
- [x] Find all Users

This pull request introduces several new features and improvements to the authentication module. The most important changes include the addition of a new `UserController` for user management, the creation of new services for user registration and retrieval, and the implementation of new exception handling for resource conflicts.

### New Features:
* [`src/main/java/org/quizzcloud/backend/auth/controller/UserController.java`](diffhunk://#diff-a9a4a016ef3874327829e54f607f13c515d5e519905b399119dd24adb15ca85eR1-R32): Added a new `UserController` to handle user registration and retrieval endpoints.
* [`src/main/java/org/quizzcloud/backend/auth/service/RegisterUserService.java`](diffhunk://#diff-1082d73bb1d47a029edc493161c57fdfa757bee83cd6bac5efa1bb5f5c27c374R1-R52): Implemented a `RegisterUserService` to handle user registration logic, including password generation and encoding.
* [`src/main/java/org/quizzcloud/backend/auth/service/FindUsersService.java`](diffhunk://#diff-aa00d21c8a0e54f6d694e3e96cf2e6b20cba12010abd3d8e65ed9c3425b133ebR1-R18): Added a `FindUsersService` to retrieve a list of all users from the repository.

### Exception Handling:
* [`src/main/java/org/quizzcloud/backend/shared/exceptions/GlobalExceptionHandler.java`](diffhunk://#diff-7c657cdd3180dd6be44b9b066ff293a275433246e17cfd0cddee15b184466863R38-R43): Updated the global exception handler to include handling for `ResourceAlreadyExistsException`.
* [`src/main/java/org/quizzcloud/backend/shared/exceptions/ResourceAlreadyExistsException.java`](diffhunk://#diff-1b2a08d5b31f6e1153a833c8eaf23685d7d0f5aecd7919b7c4b98e0703335e39R1-R7): Added a new exception class `ResourceAlreadyExistsException` to handle cases where a resource already exists.

### Security Configuration:
* [`src/main/java/org/quizzcloud/backend/auth/config/SecurityConfig.java`](diffhunk://#diff-16a64fce8d2ddf69c16c111e4e1078d9359f8f9a9c52cdbbc2af57ccee1b7becL44-R50): Updated security configuration to use `AbstractHttpConfigurer::disable` for CSRF and changed authorization rules for user endpoints.

### Testing:
* [`src/test/java/org/quizzcloud/backend/acceptance/auth/FindUsersTest.java`](diffhunk://#diff-e7a14cb9bc2db7f3ccdfc62edc4f35b21c71b198f71de3d0a4c6ed45cccfab8eR1-R18): Added an acceptance test for retrieving all users.
* [`src/test/java/org/quizzcloud/backend/acceptance/auth/RegisterUserTest.java`](diffhunk://#diff-0bdb5ea68c9c8a8d42c6306031656c3737d2c8305599bf5c96a9b293d96a84d5R1-R69): Added acceptance tests for user registration by admin and non-admin users.